### PR TITLE
Create VRC_Bombus_example422.json

### DIFF
--- a/3/schemas/VRC_Bombus_example422.json
+++ b/3/schemas/VRC_Bombus_example422.json
@@ -1,0 +1,139 @@
+{
+    "virtualReferenceCollectionMetaData": {
+        "referenceCollectionID": "http://dummydomain.referencecollections.org/bombus312",
+        "creator": "Jere Kahanpää",
+        "maintainer": "Sofie Meeus",
+        "copyrightLicense": "CC-BY",
+        "copyrightOwner": "Luomus",
+        "title": "European Bombus virtual reference collection, test 312",
+        "description": "A third test case involving Bombus virtual reference collection data. Handling some special case: 1st Taxon has no organisms, 2nd has 2 organisms, one with an occurrence with no media.",
+        "area": [
+            "Europe"
+        ],
+        "includedTaxaDescription": "Bombus"
+    },
+    "taxa": [	
+        {
+            "taxonID": "https://fauna-eu.org/cdm_dataportal/taxon/35f45551-09c1-4711-b747-99a72c8c4814",
+            "taxonValidNameID": "https://www.gbif.org/species/1340545",
+            "taxonName": {
+                "taxonNameID": "https://www.gbif.org/species/1340545",
+                "taxonFullName": "Bombus niveatus Kriechbaumer, 1870",
+                "taxonNameAuthor": "Kriechbaumer",
+                "taxonNameYear": 1870,
+                "taxonNameBrackets": "false"
+            },
+            "organisms": [
+                    ]
+        },
+		
+        {
+            "taxonID": "https://fauna-eu.org/cdm_dataportal/taxon/20ea3211-9fad-4132-a71b-f98226e71757",
+            "taxonValidNameID": "https://www.gbif.org/species/1340358",
+            "taxonName": {
+                "taxonNameID": "https://www.gbif.org/species/1340358",
+                "taxonFullName": "Bombus wurflenii Radoszkowski, 1859",
+                "taxonNameAuthor": "Radoszkowski",
+                "taxonNameYear": 1859,
+                "taxonNameBrackets": "false"
+            },
+           "organisms": [
+                {
+                    "organismID": "test_organism_with_an_occurrence_with_media",
+                    "occurrences": [
+                        {
+                            "occurrenceID": "https://www.gbif.org/occurrence/1264847616",
+                            "media": [
+                                {
+                                    "mediaID": "https://iiif.mcz.harvard.edu/iiif/3/3780060/full/max/0/default.jpg",
+                                    "documentOccurrenceID": "https://www.gbif.org/occurrence/1264847616",
+                                    "copyrightLicense": "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+                                    "mediaDataURL": "https://iiif.mcz.harvard.edu/iiif/3/3780060/full/max/0/default.jpg",
+                                    "reviewed": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+				{
+                    "organismID": "test_organism_with_an_occurrence_without_media",
+                    "occurrences": [
+                        {
+                            "occurrenceID": "dummy_occurrence_id"
+						}
+                    ]
+                }
+			]
+		},	
+					
+        {
+            "taxonID": "https://fauna-eu.org/cdm_dataportal/taxon/241aed3e-69ea-46b9-9611-d90901183da6",
+            "taxonValidNameID": "https://www.gbif.org/species/1340387",
+            "taxonName": {
+                "taxonNameID": "https://www.gbif.org/species/1340387",
+                "taxonFullName": "Bombus veteranus (Fabricius, 1793)",
+                "taxonNameAuthor": "Fabricius",
+                "taxonNameYear": 1793,
+                "taxonNameBrackets": "true"
+            },
+            "organisms": [
+                {
+                    "organismID": "Bombus_veteranus_ex1",
+                    "occurrences": [
+                        {
+                            "occurrenceID": "http://id.luomus.fi/MY.3991280",
+                            "media": [
+                                {
+                                    "mediaID": "https://image.laji.fi/MM.154455/GL.8278_Bombus_veteranus_2.jpg",
+                                    "documentOccurrenceID": "http://id.luomus.fi/MY.3991280",
+                                    "copyrightLicense": "https://creativecommons.org/licenses/by-sa/4.0/",
+                                    "mediaDataURL": "https://image.laji.fi/MM.154455/GL.8278_Bombus_veteranus_2.jpg",
+                                    "reviewed": true
+                                },
+                                {
+                                    "mediaID": "https://image.laji.fi/MM.154454/GL.8278_Bombus_veteranus_1.jpg",
+                                    "documentOccurrenceID": "http://id.luomus.fi/MY.3991280",
+                                    "copyrightLicense": "https://creativecommons.org/licenses/by-sa/4.0/",
+                                    "mediaDataURL": "https://image.laji.fi/MM.154454/GL.8278_Bombus_veteranus_1.jpg",
+                                    "reviewed": true
+                                }
+
+
+
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },	
+        {
+            "taxonID": "https://fauna-eu.org/cdm_dataportal/taxon/8c705c57-1b2f-432f-906c-e73be11198e9",
+            "taxonValidNameID": "https://www.gbif.org/species/1340311",
+            "taxonName": {
+                "taxonNameID": "https://www.gbif.org/species/1340311",
+                "taxonFullName": "Bombus laesus Morawitz, 1875",
+                "taxonNameAuthor": "Morawitz",
+                "taxonNameYear": 1875,
+                "taxonNameBrackets": "false"
+            },
+            "organisms": [
+                {
+                    "organismID": "Bombus_laesus_ex1",
+                    "occurrences": [
+                        {
+                            "occurrenceID": "https://www.gbif.org/occurrence/3437225248",
+                            "media": [
+                                {
+                                    "mediaID": "https://image.laji.fi/MM.249027/GL.8984_Bombus_laesus_f_cotype_1.jpg",
+                                    "copyrightLicense": "https://creativecommons.org/licenses/by/4.0/legalcode",
+                                    "mediaDataURL": "https://image.laji.fi/MM.249027/GL.8984_Bombus_laesus_f_cotype_1.jpg",
+                                    "reviewed": true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
A third test case involving Bombus virtual reference collection data. Handling some special case: 1st Taxon has no organisms, 2nd has 2 organisms, one with an occurrence with no media.